### PR TITLE
feat: opensearch 알림 empty list에 대한 return 처리(#27, SCRUM-205)

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
@@ -222,12 +222,12 @@ public class AlertServiceImpl implements AlertService {
 
     @Override
     public void createGrafanaAlert(AlertGrafanaRequestDto requestDto) {
-        log.info("[그라파나 알림 생성] 서비스 진입");
+        log.info("[그라파나 알림] 서비스 진입");
 
         List<AlertRequestDto> alertList = requestDto.getAlerts();
 
         if (alertList == null || alertList.isEmpty()) {
-            log.warn("[그라파나 알림 생성] 전달받은 알림 리스트가 비어있습니다.");
+            log.warn("[그라파나 알림] 전달받은 알림 리스트가 비어있습니다.");
             return;
         }
 
@@ -235,7 +235,7 @@ public class AlertServiceImpl implements AlertService {
             createAlert(alertRequest, AlertKind.GRAFANA);
         }
 
-        log.info("[그라파나 알림 생성] 전체 {}건 서비스 처리 완료", alertList.size());
+        log.info("[그라파나 알림] 전체 {}건 서비스 처리 완료", alertList.size());
     }
 
     @Override
@@ -244,7 +244,12 @@ public class AlertServiceImpl implements AlertService {
         
         String rawJson = requestDto.getRequest();
         List<AlertRequestDto> alerts = parseRawStringToDtoList(rawJson);
-        
+
+        if (alerts == null || alerts.isEmpty()) {
+            log.warn("[오픈서치 대시보드 알림] 전달받은 알림 리스트가 비어있습니다.");
+            return;
+        }
+
         for (AlertRequestDto alert : alerts) {
             AlertRequestDto alertRequest = AlertRequestDto.builder()
                     .id(alert.getId())


### PR DESCRIPTION
## #️⃣ Issue Number

#27 

## 📝 요약(Summary)
openSearch 에서 알림 전송 시 error 가 없을 경우 빈 값을 보내므로
빈 값인 경우 alert 발생 안되도록 처리하는 로직을 추가합니다.

## 📸스크린샷 (선택)
