### PR TITLE
feat: issue 공유자 employeeId 아닌 githubId 로 조회하도록 수정(#31, SCRUM-208)

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertIssueRequestDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertIssueRequestDto.java
@@ -16,6 +16,6 @@ import java.util.List;
 @AllArgsConstructor
 public class AlertIssueRequestDto {
     // TODO ISSUE 담당자 분과 협의하여 수정
-    private List<String> sharedEmployeeIds; // 이슈 공유자들
+    private List<String> assigneeGithubIds; // 이슈 공유자들
     private LocalDateTime timestamp; //이슈 생성 완료 시간
 }

--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
@@ -393,10 +393,12 @@ public class AlertServiceImpl implements AlertService {
 
             // 2. 알림 대상자 조회
             List<User> targetUsers = new ArrayList<>();
-            List<String> sharedIds = requestDto.getSharedEmployeeIds();
+            //List<String> sharedIds = requestDto.getSharedEmployeeIds();
+            List<String> sharedIds = requestDto.getAssigneeGithubIds();
 
             if (sharedIds != null && !sharedIds.isEmpty()) {
-                targetUsers = userRepository.findAllById(sharedIds);
+                //targetUsers = userRepository.findAllById(sharedIds);
+                targetUsers = userRepository.findAllByGithubIdIn(sharedIds);
 
                 if (targetUsers.isEmpty()) {
                     log.warn("[이슈 생성 알림] 공유 대상자가 존재하지 않음: {}", sharedIds);

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/repository/UserRepository.java
@@ -74,4 +74,7 @@ public interface UserRepository extends JpaRepository<User, String> {
      */
     @Query("SELECT u FROM User u WHERE u.username LIKE %:username% AND u.githubId IS NOT NULL AND u.githubId != ''")
     List<User> findByUsernameContainingIgnoreCaseAndGithubIdIsNotNull(@Param("username") String username);
+
+
+    List<User> findAllByGithubIdIn(List<String> githubIds);
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#31 

## 📝 요약(Summary)
- issue 공유자 employeeId 아닌 githubId 로 조회하도록 수정
- 기존 employeeId 조회 방식은 주석 처리
- alert 발생 위치 (웹훅 / service 직접 호출) 변경해도 좋습니다!

## 📸스크린샷 (선택)
