### PR TITLE
fix: SSE 비동기 스레드 인증 오류 및 날짜 직렬화 문제 해결

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/user/security/config/SecurityConfig.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/security/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -50,9 +51,18 @@ public class SecurityConfig {
             "/api/alert/opensearch",
             "/api/alert/devops",
             "/api/alert/",
-            "/api/issue/webhook/github",
-            "/"
+            "/api/issues/webhook/github",
+            "/",
+            "/api/logging/subscribe",
+            "/api/alert/subscribe"
     );
+
+    /**
+     * 비동기 처리를 위한 Security Context 전파 설정
+     */
+    static {
+        SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL);
+    }
 
     /**
      * JWT 인증 필터를 Bean으로 등록 (순환참조 방지)


### PR DESCRIPTION
## #️⃣ Issue Number

#20 

## 📝 요약(Summary)

- SecurityConfig에 MODE_INHERITABLETHREADLOCAL 추가하여 비동기 스레드 보안 컨텍스트 전파
- SSE 엔드포인트 접근을 위해 /api/logging/subscribe를 보안 화이트리스트에 추가
- Jackson LocalDateTime 직렬화를 배열 형태 대신 ISO 문자열 형태로 반환하도록 수정

해결된 문제:
- 비동기 스레드에서 보안 컨텍스트 누락으로 인한 SSE 연결 AuthorizationDeniedException 오류
- createdAt/updatedAt 필드가 ISO 문자열 대신 배열 형태 [2025, 6, 6, 2, 41, 36]로 반환되는 문제
- SSE 비동기 처리 중 "response has already been committed" 오류

기술적 변경사항:
- SecurityContextHolder 전략을 스레드 경계 간 보안 컨텍스트 상속으로 변경
- Jackson SerializationFeature.WRITE_DATES_AS_TIMESTAMPS 비활성화
- SSE 엔드포인트를 인증 화이트리스트에 추가

## 📸스크린샷 (선택)
