### PR TITLE
refactor: Github Issue 발생 시 payload 에 맞게 알림 전송 되도록 변경 (#31, SCRUM-208)

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/controller/AlertController.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/controller/AlertController.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import kr.ssok.ssom.backend.domain.alert.dto.*;
 import kr.ssok.ssom.backend.domain.alert.service.AlertService;
 import kr.ssok.ssom.backend.domain.user.security.principal.UserPrincipal;
+import kr.ssok.ssom.backend.global.dto.GitHubIssueResponseDto;
 import kr.ssok.ssom.backend.global.exception.BaseException;
 import kr.ssok.ssom.backend.global.exception.BaseResponse;
 import kr.ssok.ssom.backend.global.exception.BaseResponseStatus;
@@ -172,10 +173,10 @@ public class AlertController {
                 .body(new BaseResponse<>(BaseResponseStatus.SUCCESS));
     }
 
-    @Operation(summary = "이슈 생성 알림", description = "이슈 생성 시 앱으로 알림을 전송합니다.")
+    @Operation(summary = "Github 이슈 알림", description = "SSOM 에서 등록한 Github 이슈 opened/reopened/closed 시 앱으로 알림을 전송합니다.")
     @PostMapping("/issue")
     public ResponseEntity<BaseResponse<Void>> sendIssueAlert(@RequestBody AlertIssueRequestDto requestDto) {
-        log.info("[이슈 생성 알림] 컨트롤러 진입");
+        log.info("[Github 이슈 알림] 컨트롤러 진입");
 
         alertService.createIssueAlert(requestDto);
         return ResponseEntity

--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertIssueRequestDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertIssueRequestDto.java
@@ -1,21 +1,68 @@
 package kr.ssok.ssom.backend.domain.alert.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Tag(name = "AlertIssueRequestDto", description = "이슈 생성 완료 시 보내주는 포맷")
-@Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AlertIssueRequestDto {
-    // TODO ISSUE 담당자 분과 협의하여 수정
-    private List<String> assigneeGithubIds; // 이슈 공유자들
-    private LocalDateTime timestamp; //이슈 생성 완료 시간
+
+    private String action;
+    private Issue issue;
+
+    public String getAction() {
+        return action;
+    }
+
+    public Issue getIssue() {
+        return issue;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Issue {
+
+        private List<Assignee> assignees;
+
+        @JsonProperty("created_at")
+        private String createdAt;
+
+        private List<Label> labels;
+
+        public List<Assignee> getAssignees() {
+            return assignees;
+        }
+
+        public String getCreatedAt() {
+            return createdAt;
+        }
+
+        public List<Label> getLabels() {
+            return labels;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Assignee {
+        private String login;
+
+        public String getLogin() {
+            return login;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Label {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+    }
 }

--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertService.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertService.java
@@ -3,6 +3,7 @@ package kr.ssok.ssom.backend.domain.alert.service;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.ssok.ssom.backend.domain.alert.dto.*;
 import kr.ssok.ssom.backend.domain.alert.entity.constant.AlertKind;
+import kr.ssok.ssom.backend.global.dto.GitHubIssueResponseDto;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;

--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
@@ -15,6 +15,7 @@ import kr.ssok.ssom.backend.domain.user.entity.User;
 import kr.ssok.ssom.backend.domain.user.repository.UserRepository;
 import kr.ssok.ssom.backend.global.client.FirebaseClient;
 import kr.ssok.ssom.backend.global.dto.FcmMessageRequestDto;
+import kr.ssok.ssom.backend.global.dto.GitHubIssueResponseDto;
 import kr.ssok.ssom.backend.global.exception.BaseException;
 import kr.ssok.ssom.backend.global.exception.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
@@ -386,42 +387,66 @@ public class AlertServiceImpl implements AlertService {
      * 이슈 알림 처리
      *      1. createAlert 전송하지 않음 (user가 지정돼있으므로.)
      *
-     * @param requestDto : String, 리스트
+     * @param requestDto
      */
     @Override
     public void createIssueAlert(AlertIssueRequestDto requestDto) {
-        log.info("[이슈 생성 알림] 서비스 진입 : requestDto = {}", requestDto);
+        log.info("[Github 이슈 알림] 서비스 진입 : requestDto = {}", requestDto);
 
         try {
-            // 1. Alert 저장
+            // 0. 'ssom' 또는 'SSOM' 라벨이 있는지 확인
+            boolean hasSsomLabel = requestDto.getIssue().getLabels().stream()
+                    .anyMatch(label -> label.getName().equalsIgnoreCase("ssom"));
+
+            if (!hasSsomLabel) {
+                log.info("[Github 이슈 알림] 'ssom' 라벨이 없어 알림을 생성하지 않음");
+                return;
+            }
+
+            // 1. action 에 따라 title 설정
+            String alertTitle;
+            switch (requestDto.getAction()) {
+                case "opened":
+                    alertTitle = "[ISSUE] Opened";
+                    break;
+                case "reopened":
+                    alertTitle = "[ISSUE] Reopened";
+                    break;
+                case "closed":
+                    alertTitle = "[ISSUE] Closed";
+                    break;
+                default:
+                    log.warn("[Github 이슈 알림] 지원하지 않는 action 값: {}", requestDto.getAction());
+                    throw new BaseException(BaseResponseStatus.INVALID_ISSUE_ACTION);
+            }
+
+            // 2. Alert 저장
             Alert alert = Alert.builder()
                     .id(AlertKind.ISSUE + "_noNeedId")
-                    .title("[ISSUE] 이슈 공유")
-                    .message("새로운 이슈가 공유되었습니다.")
+                    .title(alertTitle)
+                    .message("Github 이슈가 공유되었습니다.")
                     .kind(AlertKind.ISSUE)
-                    .timestamp(requestDto.getTimestamp().toString())
+                    .timestamp(requestDto.getIssue().getCreatedAt())
                     .build();
             alertRepository.save(alert);
 
-            // 2. 알림 대상자 조회
-            List<User> targetUsers = new ArrayList<>();
-            //List<String> sharedIds = requestDto.getSharedEmployeeIds();
-            List<String> sharedIds = requestDto.getAssigneeGithubIds();
+            // 3. 알림 대상자 조회
+            List<String> sharedLogins = requestDto.getIssue().getAssignees().stream()
+                    .map(AlertIssueRequestDto.Assignee::getLogin)
+                    .collect(Collectors.toList());
 
-            if (sharedIds != null && !sharedIds.isEmpty()) {
-                //targetUsers = userRepository.findAllById(sharedIds);
-                targetUsers = userRepository.findAllByGithubIdIn(sharedIds);
+            if (sharedLogins.isEmpty()) {
+                log.warn("[Github 이슈 알림] 공유 대상자가 지정되지 않음");
+                return;
+            }
 
-                if (targetUsers.isEmpty()) {
-                    log.warn("[이슈 생성 알림] 공유 대상자가 존재하지 않음: {}", sharedIds);
-                    throw new BaseException(BaseResponseStatus.ALERT_TARGET_USER_NOT_FOUND);
-                }
-            } else {
-                log.warn("[이슈 생성 알림] 공유 대상자가 지정되지 않음");
+            List<User> targetUsers = userRepository.findAllByGithubIdIn(sharedLogins);
+            if (targetUsers.isEmpty()) {
+                log.warn("[Github 이슈 알림] 공유 대상자가 존재하지 않음: {}", sharedLogins);
                 throw new BaseException(BaseResponseStatus.ALERT_TARGET_USER_NOT_FOUND);
             }
 
-            // 3. AlertStatus 생성 및 전송
+            // 4. AlertStatus 생성 및 전송
             for (User user : targetUsers) {
                 AlertStatus alertStatus = AlertStatus.builder()
                         .alert(alert)
@@ -434,11 +459,11 @@ public class AlertServiceImpl implements AlertService {
                 sendAlertToUser(user.getId(), responseDto);
             }
 
-            log.info("[이슈 생성 알림] 서비스 처리 완료");
+            log.info("[Github 이슈 알림] 서비스 처리 완료");
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {
-            log.error("[이슈 생성 알림] 처리 중 예외 발생", e);
+            log.error("[Github 이슈 알림] 처리 중 예외 발생", e);
             throw new BaseException(BaseResponseStatus.ALERT_CREATE_FAILED);
         }
     }

--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/service/AlertServiceImpl.java
@@ -416,8 +416,8 @@ public class AlertServiceImpl implements AlertService {
                     alertTitle = "[ISSUE] Closed";
                     break;
                 default:
-                    log.warn("[Github 이슈 알림] 지원하지 않는 action 값: {}", requestDto.getAction());
-                    throw new BaseException(BaseResponseStatus.INVALID_ISSUE_ACTION);
+                    log.warn("[Github 이슈 알림] 알림 전송으로 지원하지 않는 action 값: {}", requestDto.getAction());
+                    return;
             }
 
             // 2. Alert 저장

--- a/src/main/java/kr/ssok/ssom/backend/global/exception/BaseResponseStatus.java
+++ b/src/main/java/kr/ssok/ssom/backend/global/exception/BaseResponseStatus.java
@@ -52,13 +52,14 @@ public enum BaseResponseStatus {
     LLM_API_ERROR(false, 6003, "LLM API 호출 중 오류가 발생했습니다."),
     NOT_FOUND_LOG(false, 6004, "로그를 찾을 수 없습니다."),
     GITHUB_API_ERROR(false, 6005, "GitHub API 호출 중 오류가 발생했습니다."),
+    INVALID_ISSUE_ACTION(false, 6006, "지원하지 않는 action 값 입니다."),
 
     // 알림 관련 오류
     SSE_BAD_REQUEST(false, 7001, "SSE 구독을 위한 사용자 정보가 전달되지 않았습니다."),
     SSE_INIT_ERROR(false, 7002, "SSE 구독 처리 중 오류가 발생했습니다."),
     NOT_FOUND_ALERT(false, 7003, "Alert를 찾을 수 없습니다."),
     PARSING_ERROR(false, 7004, "Json Parsing 오류가 발생했습니다."),
-    ALERT_TARGET_USER_NOT_FOUND(false, 7005, "Issue 생성 알림 공유 대상자가 조회되지 않습니다."),
+    ALERT_TARGET_USER_NOT_FOUND(false, 7005, "Github 이슈 알림 공유 대상자가 조회되지 않습니다."),
     ALERT_CREATE_FAILED(false, 7006, "알림 생성 중 오류가 발생했습니다."),
     UNSUPPORTED_ALERT_KIND(false, 7007, "알림 유형이 유효하지 않습니다."),
     REDIS_ACCESS_FAILED(false, 7008, "Redis 접근에 실패하였습니다."),


### PR DESCRIPTION
## #️⃣ Issue Number

#31 

## 📝 요약(Summary)
- 이슈 알림에 대해 내부에서 통신하지 않고, Webhoook에서 전송받은 데이터로 알림 생성
- Github Payload 데이터 형식에 맞게 Alert 처리되도록 수정
- Alert 발생 조건 : Issues > Labels > name 에 ssom 이 있는 건 중 Opened/Reopened/Closed 만 처리.

## 📸스크린샷 (선택)
