### PR TITLE
fix: 알림 전체 목록 조회 및 읽음 처리시 alertStatusID 주고받도록 처리

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertResponseDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertResponseDto.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class AlertResponseDto {
     private Long alertId;
+    private Long alertStatusId;
     private String id;
     private String title;
     private String message;
@@ -27,7 +28,8 @@ public class AlertResponseDto {
     public static AlertResponseDto from(AlertStatus status) {
         Alert alert = status.getAlert();
         return AlertResponseDto.builder()
-                .alertId(alert.getAlertId())            // 예 : 1
+                .alertId(alert.getAlertId())                // 예 : 1
+                .alertStatusId(status.getAlertStatusId())   // 예 : 2
                 .id(alert.getId())                      // 예 : "686692198126160f"
                 .title(alert.getTitle())                // 예 : [ERROR] ssok-bank
                 .message(alert.getMessage())            // 예 : "Authentication error: Authorization header is missing or invalid"


### PR DESCRIPTION
## #️⃣ Issue Number

#31
#34 

## 📝 요약(Summary)

알림 목록 조회 시 alertStatusId 를 전송하여 개별 알림에 대한 ID를 주고 받아 상태 변경을 할 수 있게 수정

## 📸스크린샷 (선택)
