### PR TITLE
fix: isRead 필드 @JsonProperty 적용

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertModifyRequestDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertModifyRequestDto.java
@@ -1,5 +1,6 @@
 package kr.ssok.ssom.backend.domain.alert.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AlertModifyRequestDto {
     private Long alertStatusId;
+
+    @JsonProperty("isRead")
     private boolean isRead;
 }
 

--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertResponseDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/dto/AlertResponseDto.java
@@ -1,5 +1,6 @@
 package kr.ssok.ssom.backend.domain.alert.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ssok.ssom.backend.domain.alert.entity.Alert;
 import kr.ssok.ssom.backend.domain.alert.entity.AlertStatus;
@@ -20,7 +21,10 @@ public class AlertResponseDto {
     private String title;
     private String message;
     private String kind;
+
+    @JsonProperty("isRead")
     private boolean isRead;
+
     private String timestamp;
     private LocalDateTime createdAt;
     private String employeeId;


### PR DESCRIPTION
## #️⃣ Issue Number

#34

## 📝 요약(Summary)
- Jackson 이 boolean 필드를 직렬화하면서 "is"를 제거하는 기본 동작이 있음
- AlertModifyRequestDto 및 AlertResponseDto에 isRead 필드 @JsonProperty 적용하여 필드명 누락안되게 처리

## 📸스크린샷 (선택)
