### PR TITLE
feat: LoginResponseDto 필드 누락 수정

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/controller/UserController.java
@@ -83,4 +83,6 @@ public class UserController {
         
         return ResponseEntity.ok(new BaseResponse<>(BaseResponseStatus.SUCCESS, userInfo));
     }
+
+    // 부서별 유저 정보
 }

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/repository/BiometricInfoRepository.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/repository/BiometricInfoRepository.java
@@ -45,6 +45,11 @@ public interface BiometricInfoRepository extends JpaRepository<BiometricInfo, Lo
             String employeeId, String deviceId);
 
     /**
+     * 사용자의 생체인증 등록 여부 확인 (전체 기기)
+     */
+    boolean existsByEmployeeIdAndIsActiveTrue(String employeeId);
+
+    /**
      * 사용자의 활성화된 생체인증 정보 개수 조회
      */
     int countByEmployeeIdAndIsActiveTrue(String employeeId);


### PR DESCRIPTION
## #️⃣ Issue Number

#98 

## 📝 요약(Summary)

- 일반 로그인 시 누락된 username, expiresIn, biometricEnabled, lastLoginAt 필드 추가
- 생체인증 로그인 시 누락된 refreshToken, expiresIn, lastLoginAt 필드 추가  
- 토큰 갱신 시 누락된 username, department, expiresIn, biometricEnabled, lastLoginAt 필드 추가
- UserServiceImpl에 생체인증 등록 여부 확인 메서드 추가
- BiometricService에 Refresh Token Redis 저장 로직 추가
- BiometricInfoRepository에 existsByEmployeeIdAndIsActiveTrue 메서드 추가
- 모든 로그인 방식에서 일관된 응답 형식 보장

## 📸스크린샷 (선택)
