### PR TITLE
feat: 모든 사용자 목록 조회 API 추가

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/controller/UserController.java
@@ -13,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/users")
@@ -23,8 +25,7 @@ public class UserController {
     // 회원가입
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<Void>> registerUser(
-            @Valid @RequestBody SignupRequestDto requestDto) {
-        log.info("회원가입 요청 - 전달받은 departmentCode: {}", requestDto.getDepartmentCode());
+            @RequestBody SignupRequestDto requestDto) {
         userService.registerUser(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new BaseResponse<>(BaseResponseStatus.REGISTER_USER_SUCCESS));
@@ -82,6 +83,17 @@ public class UserController {
         UserResponseDto userInfo = userService.getUserInfo(userPrincipal.getEmployeeId());
         
         return ResponseEntity.ok(new BaseResponse<>(BaseResponseStatus.SUCCESS, userInfo));
+    }
+
+    // 모든 사용자 목록 조회
+    @GetMapping("/list")
+    public ResponseEntity<BaseResponse<List<UserListResponseDto>>> getAllUsers() {
+
+        log.info("모든 사용자 목록 조회 요청");
+
+        List<UserListResponseDto> userList = userService.getAllUsers();
+
+        return ResponseEntity.ok(new BaseResponse<>(BaseResponseStatus.SUCCESS, userList));
     }
 
     // 부서별 유저 정보

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/dto/UserListResponseDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/dto/UserListResponseDto.java
@@ -1,0 +1,41 @@
+package kr.ssok.ssom.backend.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.ssok.ssom.backend.domain.user.entity.User;
+import lombok.*;
+
+/**
+ * 사용자 목록 조회 응답 DTO
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 목록 조회 응답")
+public class UserListResponseDto {
+    
+    @Schema(description = "사원번호", example = "CHN0001")
+    private String id;
+    
+    @Schema(description = "사용자명", example = "홍길동")
+    private String username;
+    
+    @Schema(description = "부서", example = "CHANNEL")
+    private String department;
+    
+    @Schema(description = "GitHub ID", example = "hong-gildong")
+    private String githubId;
+    
+    /**
+     * User 엔티티로부터 UserListResponseDto 생성
+     */
+    public static UserListResponseDto from(User user) {
+        return UserListResponseDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .department(user.getDepartment().name())
+                .githubId(user.getGithubId())
+                .build();
+    }
+}

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/repository/UserRepository.java
@@ -83,4 +83,10 @@ public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByGithubId(String githubId);
 
     List<User> findAllByGithubIdIn(List<String> githubIds);
+
+    /**
+     * 모든 사용자를 사원번호 순으로 조회
+     * @return 사원번호 오름차순으로 정렬된 모든 사용자 목록
+     */
+    List<User> findAllByOrderByIdAsc();
 }

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/UserServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/UserServiceImpl.java
@@ -5,11 +5,12 @@ import kr.ssok.ssom.backend.domain.user.dto.LoginResponseDto;
 import kr.ssok.ssom.backend.domain.user.dto.PasswordChangeRequestDto;
 import kr.ssok.ssom.backend.domain.user.dto.SignupRequestDto;
 import kr.ssok.ssom.backend.domain.user.dto.UserResponseDto;
+import kr.ssok.ssom.backend.domain.user.dto.UserListResponseDto;
 import kr.ssok.ssom.backend.domain.user.entity.Department;
 import kr.ssok.ssom.backend.domain.user.entity.User;
+import kr.ssok.ssom.backend.domain.user.repository.BiometricInfoRepository;
 import kr.ssok.ssom.backend.domain.user.security.jwt.JwtTokenProvider;
 import kr.ssok.ssom.backend.domain.user.repository.UserRepository;
-import kr.ssok.ssom.backend.domain.user.repository.BiometricInfoRepository;
 import kr.ssok.ssom.backend.domain.user.service.UserService;
 import kr.ssok.ssom.backend.global.exception.BaseException;
 import kr.ssok.ssom.backend.global.exception.BaseResponseStatus;
@@ -20,7 +21,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -305,5 +308,24 @@ public class UserServiceImpl implements UserService {
      */
     private boolean checkBiometricEnabled(String employeeId) {
         return biometricInfoRepository.existsByEmployeeIdAndIsActiveTrue(employeeId);
+    }
+
+    /**
+     * 모든 사용자 목록 조회
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserListResponseDto> getAllUsers() {
+        log.info("모든 사용자 목록 조회 요청");
+
+        List<User> users = userRepository.findAllByOrderByIdAsc();
+
+        List<UserListResponseDto> userList = users.stream()
+                .map(UserListResponseDto::from)
+                .collect(Collectors.toList());
+
+        log.info("사용자 목록 조회 완료 - 총 {}명", userList.size());
+
+        return userList;
     }
 }

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/service/UserService.java
@@ -6,7 +6,10 @@ import kr.ssok.ssom.backend.domain.user.dto.LoginResponseDto;
 import kr.ssok.ssom.backend.domain.user.dto.PasswordChangeRequestDto;
 import kr.ssok.ssom.backend.domain.user.dto.SignupRequestDto;
 import kr.ssok.ssom.backend.domain.user.dto.UserResponseDto;
+import kr.ssok.ssom.backend.domain.user.dto.UserListResponseDto;
 import kr.ssok.ssom.backend.domain.user.entity.User;
+
+import java.util.List;
 
 public interface UserService {
     
@@ -44,4 +47,9 @@ public interface UserService {
      * 비밀번호 변경
      */
     void changePassword(String employeeId, PasswordChangeRequestDto request);
+    
+    /**
+     * 모든 사용자 목록 조회
+     */
+    List<UserListResponseDto> getAllUsers();
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#2 

## 📝 요약(Summary)

- GET /api/users/list 엔드포인트 구현
- UserListResponseDto 응답 전용 DTO 생성 (id, username, department, githubId)
- UserService.getAllUsers() 메서드 추가
- UserRepository.findAllByOrderByIdAsc() 메서드 추가
- 사원번호 오름차순 정렬로 모든 사용자 반환
- 읽기 전용 트랜잭션 적용 및 로깅 추가

## 📸스크린샷 (선택)
