### PR TITLE
fix: OpenSearch 실시간 로그 내용 빈 경우 return

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/logging/service/Impl/LoggingServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/logging/service/Impl/LoggingServiceImpl.java
@@ -254,7 +254,7 @@ public class LoggingServiceImpl implements LoggingService {
 
             if (loggingList == null || loggingList.isEmpty()) {
                 log.warn("[오픈서치 실시간 로그] Json 파싱 결과 실시간 로그 리스트가 비어있습니다.");
-                throw new BaseException(BaseResponseStatus.PARSING_ERROR);
+                return;
             }
 
             for (LogDto loggingRequest : loggingList) {


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)

- OpenSearch 실시간 로그 내용 빈 경우
  - 변경 전: 예외 처리
  - 변경 후: return

## 📸스크린샷 (선택)
