### PR TITLE
test : BiometricFailureService 개선 및 통합테스트

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/user/service/BiometricFailureService.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/service/BiometricFailureService.java
@@ -1,117 +1,49 @@
 package kr.ssok.ssom.backend.domain.user.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class BiometricFailureService {
-
-    private final RedisTemplate<String, String> redisTemplate;
-
-    private static final String BIOMETRIC_FAIL_KEY = "biometric:fail:";
-    private static final String BIOMETRIC_BLOCK_KEY = "biometric:block:";
-    private static final Duration FAIL_COUNT_TTL = Duration.ofMinutes(30);
-    private static final Duration BLOCK_DURATION = Duration.ofMinutes(30);
-    private static final int MAX_ATTEMPTS = 3;
+public interface BiometricFailureService {
 
     /**
      * 실패 횟수 증가
      */
-    public int incrementFailCount(String employeeId, String deviceId) {
-        String key = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
-        String count = redisTemplate.opsForValue().get(key);
-
-        int newCount = (count != null ? Integer.parseInt(count) : 0) + 1;
-        redisTemplate.opsForValue().set(key, String.valueOf(newCount), FAIL_COUNT_TTL);
-
-        log.debug("생체인증 실패 횟수 증가 - 사원번호: {}, 디바이스: {}, 횟수: {}", employeeId, deviceId, newCount);
-
-        return newCount;
-    }
+    int incrementFailCount(String employeeId, String deviceId);
 
     /**
      * 실패 횟수 초기화
      */
-    public void clearFailCount(String employeeId, String deviceId) {
-        String key = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
-        redisTemplate.delete(key);
-        log.debug("생체인증 실패 횟수 초기화 - 사원번호: {}, 디바이스: {}", employeeId, deviceId);
-    }
+    void clearFailCount(String employeeId, String deviceId);
 
     /**
      * 현재 실패 횟수 조회
      */
-    public int getFailCount(String employeeId, String deviceId) {
-        String key = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
-        String count = redisTemplate.opsForValue().get(key);
-        return count != null ? Integer.parseInt(count) : 0;
-    }
+    int getFailCount(String employeeId, String deviceId);
 
     /**
      * 최대 시도 횟수 초과 여부 확인
      */
-    public boolean hasExceededMaxAttempts(String employeeId, String deviceId) {
-        return getFailCount(employeeId, deviceId) >= MAX_ATTEMPTS;
-    }
+    boolean hasExceededMaxAttempts(String employeeId, String deviceId);
 
     /**
      * 디바이스 차단
      */
-    public void blockDevice(String employeeId, String deviceId) {
-        String key = BIOMETRIC_BLOCK_KEY + employeeId + ":" + deviceId;
-        redisTemplate.opsForValue().set(key, "blocked", BLOCK_DURATION);
-        log.warn("디바이스 차단됨 - 사원번호: {}, 디바이스: {}, 기간: {}분", 
-                employeeId, deviceId, BLOCK_DURATION.toMinutes());
-    }
+    void blockDevice(String employeeId, String deviceId);
 
     /**
      * 디바이스 차단 상태 확인
      */
-    public boolean isDeviceBlocked(String employeeId, String deviceId) {
-        String key = BIOMETRIC_BLOCK_KEY + employeeId + ":" + deviceId;
-        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
-    }
+    boolean isDeviceBlocked(String employeeId, String deviceId);
 
     /**
      * 디바이스 차단 해제
      */
-    public void unblockDevice(String employeeId, String deviceId) {
-        String failKey = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
-        String blockKey = BIOMETRIC_BLOCK_KEY + employeeId + ":" + deviceId;
-        
-        redisTemplate.delete(failKey);
-        redisTemplate.delete(blockKey);
-        
-        log.info("디바이스 차단 해제 - 사원번호: {}, 디바이스: {}", employeeId, deviceId);
-    }
+    void unblockDevice(String employeeId, String deviceId);
 
     /**
      * 남은 시도 횟수 반환
      */
-    public int getRemainingAttempts(String employeeId, String deviceId) {
-        int failCount = getFailCount(employeeId, deviceId);
-        return Math.max(0, MAX_ATTEMPTS - failCount);
-    }
+    int getRemainingAttempts(String employeeId, String deviceId);
 
     /**
      * 사용자의 모든 디바이스 차단 해제 (일반 로그인 성공 시 사용)
      */
-    public void unblockAllDevicesForUser(String employeeId) {
-        String failPattern = BIOMETRIC_FAIL_KEY + employeeId + ":*";
-        String blockPattern = BIOMETRIC_BLOCK_KEY + employeeId + ":*";
-        
-        // 실패 카운트 관련 모든 키 삭제
-        redisTemplate.delete(redisTemplate.keys(failPattern));
-        
-        // 차단 관련 모든 키 삭제  
-        redisTemplate.delete(redisTemplate.keys(blockPattern));
-        
-        log.info("사용자의 모든 디바이스 차단 해제 - 사원번호: {}", employeeId);
-    }
+    void unblockAllDevicesForUser(String employeeId);
 }

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/BiometricFailureServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/BiometricFailureServiceImpl.java
@@ -1,0 +1,231 @@
+package kr.ssok.ssom.backend.domain.user.service.Impl;
+
+import kr.ssok.ssom.backend.domain.user.service.BiometricFailureService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BiometricFailureServiceImpl implements BiometricFailureService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String BIOMETRIC_FAIL_KEY = "biometric:fail:";
+    private static final String BIOMETRIC_BLOCK_KEY = "biometric:block:";
+    private static final String USER_DEVICES_KEY = "biometric:devices:";
+    private static final Duration FAIL_COUNT_TTL = Duration.ofMinutes(30);
+    private static final Duration BLOCK_DURATION = Duration.ofMinutes(30);
+    private static final int MAX_ATTEMPTS = 3;
+
+    // Lua 스크립트로 원자적 increment 연산
+    private static final String INCREMENT_SCRIPT = 
+        "local key = KEYS[1]\n" +
+        "local ttl = tonumber(ARGV[1])\n" +
+        "local current = redis.call('GET', key)\n" +
+        "local newValue = (current and tonumber(current) or 0) + 1\n" +
+        "redis.call('SET', key, newValue, 'EX', ttl)\n" +
+        "return newValue";
+
+    /**
+     * 실패 횟수 증가 (원자적 연산)
+     */
+    @Override
+    public int incrementFailCount(String employeeId, String deviceId) {
+        validateInput(employeeId, deviceId);
+        
+        String key = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
+        String devicesKey = USER_DEVICES_KEY + employeeId;
+        
+        try {
+            // 원자적으로 실패 횟수 증가
+            DefaultRedisScript<Long> script = new DefaultRedisScript<>(INCREMENT_SCRIPT, Long.class);
+            Long newCount = redisTemplate.execute(script, 
+                Arrays.asList(key), 
+                String.valueOf(FAIL_COUNT_TTL.getSeconds()));
+            
+            // 사용자의 디바이스 목록에 추가 (차후 일괄 해제용)
+            redisTemplate.opsForSet().add(devicesKey, deviceId);
+            redisTemplate.expire(devicesKey, Duration.ofHours(24)); // 24시간 유지
+            
+            int count = newCount != null ? newCount.intValue() : 1;
+            log.debug("생체인증 실패 횟수 증가 - 사원번호: {}, 디바이스: {}, 횟수: {}", employeeId, deviceId, count);
+            
+            return count;
+        } catch (Exception e) {
+            log.error("실패 횟수 증가 중 오류 발생 - 사원번호: {}, 디바이스: {}", employeeId, deviceId, e);
+            return 1; // 기본값 반환
+        }
+    }
+
+    /**
+     * 실패 횟수 초기화
+     */
+    @Override
+    public void clearFailCount(String employeeId, String deviceId) {
+        validateInput(employeeId, deviceId);
+        
+        String key = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
+        redisTemplate.delete(key);
+        log.debug("생체인증 실패 횟수 초기화 - 사원번호: {}, 디바이스: {}", employeeId, deviceId);
+    }
+
+    /**
+     * 현재 실패 횟수 조회
+     */
+    @Override
+    public int getFailCount(String employeeId, String deviceId) {
+        validateInput(employeeId, deviceId);
+        
+        String key = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
+        try {
+            String count = redisTemplate.opsForValue().get(key);
+            return count != null ? Integer.parseInt(count) : 0;
+        } catch (NumberFormatException e) {
+            log.warn("실패 횟수 파싱 오류 - 사원번호: {}, 디바이스: {}, 값: {}", employeeId, deviceId, 
+                redisTemplate.opsForValue().get(key), e);
+            // 잘못된 값이 저장된 경우 초기화
+            clearFailCount(employeeId, deviceId);
+            return 0;
+        }
+    }
+
+    /**
+     * 최대 시도 횟수 초과 여부 확인
+     */
+    @Override
+    public boolean hasExceededMaxAttempts(String employeeId, String deviceId) {
+        return getFailCount(employeeId, deviceId) >= MAX_ATTEMPTS;
+    }
+
+    /**
+     * 디바이스 차단
+     */
+    @Override
+    public void blockDevice(String employeeId, String deviceId) {
+        validateInput(employeeId, deviceId);
+        
+        String key = BIOMETRIC_BLOCK_KEY + employeeId + ":" + deviceId;
+        redisTemplate.opsForValue().set(key, "blocked", BLOCK_DURATION);
+        log.warn("디바이스 차단됨 - 사원번호: {}, 디바이스: {}, 기간: {}분", 
+                employeeId, deviceId, BLOCK_DURATION.toMinutes());
+    }
+
+    /**
+     * 디바이스 차단 상태 확인
+     */
+    @Override
+    public boolean isDeviceBlocked(String employeeId, String deviceId) {
+        validateInput(employeeId, deviceId);
+        
+        String key = BIOMETRIC_BLOCK_KEY + employeeId + ":" + deviceId;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    /**
+     * 디바이스 차단 해제
+     */
+    @Override
+    public void unblockDevice(String employeeId, String deviceId) {
+        validateInput(employeeId, deviceId);
+        
+        String failKey = BIOMETRIC_FAIL_KEY + employeeId + ":" + deviceId;
+        String blockKey = BIOMETRIC_BLOCK_KEY + employeeId + ":" + deviceId;
+        
+        redisTemplate.delete(failKey);
+        redisTemplate.delete(blockKey);
+        
+        log.info("디바이스 차단 해제 - 사원번호: {}, 디바이스: {}", employeeId, deviceId);
+    }
+
+    /**
+     * 남은 시도 횟수 반환
+     */
+    @Override
+    public int getRemainingAttempts(String employeeId, String deviceId) {
+        int failCount = getFailCount(employeeId, deviceId);
+        return Math.max(0, MAX_ATTEMPTS - failCount);
+    }
+
+    /**
+     * 사용자의 모든 디바이스 차단 해제 (개선된 버전)
+     */
+    @Override
+    public void unblockAllDevicesForUser(String employeeId) {
+        if (employeeId == null || employeeId.trim().isEmpty()) {
+            log.warn("사원번호가 비어있음");
+            return;
+        }
+        
+        try {
+            String devicesKey = USER_DEVICES_KEY + employeeId;
+            Set<String> deviceIds = redisTemplate.opsForSet().members(devicesKey);
+            
+            if (deviceIds != null && !deviceIds.isEmpty()) {
+                for (String deviceId : deviceIds) {
+                    unblockDevice(employeeId, deviceId);
+                }
+                // 디바이스 목록도 삭제
+                redisTemplate.delete(devicesKey);
+                
+                log.info("사용자의 모든 디바이스 차단 해제 완료 - 사원번호: {}, 디바이스 수: {}", 
+                    employeeId, deviceIds.size());
+            } else {
+                // Set에 디바이스가 없는 경우 fallback으로 패턴 검색 (제한적으로 사용)
+                fallbackUnblockAllDevices(employeeId);
+            }
+        } catch (Exception e) {
+            log.error("모든 디바이스 차단 해제 중 오류 발생 - 사원번호: {}", employeeId, e);
+            // 오류 발생 시 fallback 메서드 사용
+            fallbackUnblockAllDevices(employeeId);
+        }
+    }
+
+    /**
+     * 패턴 검색을 이용한 fallback 메서드
+     */
+    private void fallbackUnblockAllDevices(String employeeId) {
+        try {
+            String failPattern = BIOMETRIC_FAIL_KEY + employeeId + ":*";
+            String blockPattern = BIOMETRIC_BLOCK_KEY + employeeId + ":*";
+            
+            Set<String> failKeys = redisTemplate.keys(failPattern);
+            Set<String> blockKeys = redisTemplate.keys(blockPattern);
+            
+            int deletedCount = 0;
+            if (failKeys != null && !failKeys.isEmpty()) {
+                redisTemplate.delete(failKeys);
+                deletedCount += failKeys.size();
+            }
+            
+            if (blockKeys != null && !blockKeys.isEmpty()) {
+                redisTemplate.delete(blockKeys);
+                deletedCount += blockKeys.size();
+            }
+            
+            log.info("Fallback: 사용자의 모든 디바이스 차단 해제 - 사원번호: {}, 삭제된 키: {}", 
+                employeeId, deletedCount);
+        } catch (Exception e) {
+            log.error("Fallback 모든 디바이스 차단 해제 중 오류 발생 - 사원번호: {}", employeeId, e);
+        }
+    }
+
+    /**
+     * 입력값 검증
+     */
+    private void validateInput(String employeeId, String deviceId) {
+        if (employeeId == null || employeeId.trim().isEmpty()) {
+            throw new IllegalArgumentException("사원번호는 필수입니다");
+        }
+        if (deviceId == null || deviceId.trim().isEmpty()) {
+            throw new IllegalArgumentException("디바이스 ID는 필수입니다");
+        }
+    }
+}

--- a/src/test/java/kr/ssok/ssom/backend/domain/user/service/BiometricFailureServiceTest.java
+++ b/src/test/java/kr/ssok/ssom/backend/domain/user/service/BiometricFailureServiceTest.java
@@ -1,0 +1,482 @@
+package kr.ssok.ssom.backend.domain.user.service;
+
+import kr.ssok.ssom.backend.domain.user.service.Impl.BiometricFailureServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BiometricFailureService 테스트")
+class BiometricFailureServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private SetOperations<String, String> setOperations;
+
+    @InjectMocks
+    private BiometricFailureServiceImpl biometricFailureService;
+
+    private static final String TEST_EMPLOYEE_ID = "CHN0001";
+    private static final String TEST_DEVICE_ID = "DEVICE001";
+
+    @Nested
+    @DisplayName("실패 횟수 증가 테스트")
+    class IncrementFailCountTest {
+
+        @Test
+        @DisplayName("첫 번째 실패 시 카운트가 1이 된다")
+        void incrementFailCount_FirstFailure_ReturnsOne() {
+            // given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), anyString()))
+                    .thenReturn(1L);
+
+            // when
+            int result = biometricFailureService.incrementFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("연속 실패 시 카운트가 누적된다")
+        void incrementFailCount_ConsecutiveFailures_IncrementsCount() {
+            // given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), anyString()))
+                    .thenReturn(2L);
+
+            // when
+            int result = biometricFailureService.incrementFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("사원번호가 null일 때 예외가 발생한다")
+        void incrementFailCount_NullEmployeeId_ThrowsException() {
+            // when & then
+            assertThatThrownBy(() ->
+                    biometricFailureService.incrementFailCount(null, TEST_DEVICE_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("사원번호는 필수입니다");
+        }
+
+        @Test
+        @DisplayName("디바이스 ID가 null일 때 예외가 발생한다")
+        void incrementFailCount_NullDeviceId_ThrowsException() {
+            // when & then
+            assertThatThrownBy(() ->
+                    biometricFailureService.incrementFailCount(TEST_EMPLOYEE_ID, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("디바이스 ID는 필수입니다");
+        }
+
+        @Test
+        @DisplayName("빈 문자열 입력 시 예외가 발생한다")
+        void incrementFailCount_EmptyString_ThrowsException() {
+            // when & then
+            assertThatThrownBy(() ->
+                    biometricFailureService.incrementFailCount("", TEST_DEVICE_ID))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("Redis 오류 시 기본값 1을 반환한다")
+        void incrementFailCount_RedisError_ReturnsDefaultValue() {
+            // given
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), anyString()))
+                    .thenThrow(new RuntimeException("Redis connection error"));
+
+            // when
+            int result = biometricFailureService.incrementFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 횟수 조회 테스트")
+    class GetFailCountTest {
+
+        @Test
+        @DisplayName("실패 기록이 없으면 0을 반환한다")
+        void getFailCount_NoRecord_ReturnsZero() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            int result = biometricFailureService.getFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("실패 기록이 있으면 해당 값을 반환한다")
+        void getFailCount_HasRecord_ReturnsCount() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn("2");
+
+            // when
+            int result = biometricFailureService.getFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("잘못된 형식의 값이 저장된 경우 0을 반환하고 키를 삭제한다")
+        void getFailCount_InvalidFormat_ReturnsZeroAndClearsKey() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn("invalid_number");
+
+            // when
+            int result = biometricFailureService.getFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(0);
+            verify(redisTemplate).delete(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 횟수 초기화 테스트")
+    class ClearFailCountTest {
+
+        @Test
+        @DisplayName("실패 횟수를 성공적으로 초기화한다")
+        void clearFailCount_Success() {
+            // when
+            biometricFailureService.clearFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            verify(redisTemplate).delete(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("최대 시도 횟수 초과 확인 테스트")
+    class HasExceededMaxAttemptsTest {
+
+        @Test
+        @DisplayName("실패 횟수가 3 미만이면 false를 반환한다")
+        void hasExceededMaxAttempts_LessThanThree_ReturnsFalse() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn("2");
+
+            // when
+            boolean result = biometricFailureService.hasExceededMaxAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패 횟수가 3 이상이면 true를 반환한다")
+        void hasExceededMaxAttempts_ThreeOrMore_ReturnsTrue() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn("3");
+
+            // when
+            boolean result = biometricFailureService.hasExceededMaxAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패 기록이 없으면 false를 반환한다")
+        void hasExceededMaxAttempts_NoRecord_ReturnsFalse() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            boolean result = biometricFailureService.hasExceededMaxAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("디바이스 차단 테스트")
+    class BlockDeviceTest {
+
+        @Test
+        @DisplayName("디바이스를 성공적으로 차단한다")
+        void blockDevice_Success() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+            // when
+            biometricFailureService.blockDevice(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            verify(valueOperations).set(anyString(), eq("blocked"), any(Duration.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("디바이스 차단 상태 확인 테스트")
+    class IsDeviceBlockedTest {
+
+        @Test
+        @DisplayName("차단된 디바이스는 true를 반환한다")
+        void isDeviceBlocked_BlockedDevice_ReturnsTrue() {
+            // given
+            when(redisTemplate.hasKey(anyString())).thenReturn(true);
+
+            // when
+            boolean result = biometricFailureService.isDeviceBlocked(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("차단되지 않은 디바이스는 false를 반환한다")
+        void isDeviceBlocked_NotBlockedDevice_ReturnsFalse() {
+            // given
+            when(redisTemplate.hasKey(anyString())).thenReturn(false);
+
+            // when
+            boolean result = biometricFailureService.isDeviceBlocked(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("디바이스 차단 해제 테스트")
+    class UnblockDeviceTest {
+
+        @Test
+        @DisplayName("디바이스 차단을 성공적으로 해제한다")
+        void unblockDevice_Success() {
+            // when
+            biometricFailureService.unblockDevice(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            verify(redisTemplate, times(2)).delete(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("남은 시도 횟수 테스트")
+    class GetRemainingAttemptsTest {
+
+        @Test
+        @DisplayName("실패 횟수에 따른 남은 시도 횟수를 정확히 계산한다")
+        void getRemainingAttempts_CalculatesCorrectly() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn("1");
+
+            // when
+            int result = biometricFailureService.getRemainingAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(2); // 3 - 1 = 2
+        }
+
+        @Test
+        @DisplayName("실패 횟수가 최대값을 초과해도 0을 반환한다")
+        void getRemainingAttempts_ExceedsMax_ReturnsZero() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn("5");
+
+            // when
+            int result = biometricFailureService.getRemainingAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("실패 기록이 없으면 최대 시도 횟수를 반환한다")
+        void getRemainingAttempts_NoFailures_ReturnsMaxAttempts() {
+            // given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            int result = biometricFailureService.getRemainingAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // then
+            assertThat(result).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 모든 디바이스 차단 해제 테스트")
+    class UnblockAllDevicesForUserTest {
+
+        @Test
+        @DisplayName("Set에 저장된 디바이스들을 모두 해제한다")
+        void unblockAllDevicesForUser_WithDevicesInSet_UnblocksAll() {
+            // given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            Set<String> deviceIds = new HashSet<>(Arrays.asList("DEVICE001", "DEVICE002", "DEVICE003"));
+            when(setOperations.members(anyString())).thenReturn(deviceIds);
+
+            // when
+            biometricFailureService.unblockAllDevicesForUser(TEST_EMPLOYEE_ID);
+
+            // then
+            verify(redisTemplate, atLeast(1)).delete(anyString());
+        }
+
+        @Test
+        @DisplayName("Set이 비어있으면 fallback 메서드를 사용한다")
+        void unblockAllDevicesForUser_EmptySet_UsesFallback() {
+            // given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(setOperations.members(anyString())).thenReturn(new HashSet<>());
+
+            Set<String> failKeys = new HashSet<>(Arrays.asList("biometric:fail:" + TEST_EMPLOYEE_ID + ":DEVICE001"));
+            Set<String> blockKeys = new HashSet<>(Arrays.asList("biometric:block:" + TEST_EMPLOYEE_ID + ":DEVICE001"));
+
+            when(redisTemplate.keys(anyString())).thenReturn(failKeys, blockKeys);
+
+            // when
+            biometricFailureService.unblockAllDevicesForUser(TEST_EMPLOYEE_ID);
+
+            // then
+            verify(redisTemplate, times(2)).keys(anyString());
+        }
+
+        @Test
+        @DisplayName("사원번호가 null이면 경고 로그만 남기고 종료한다")
+        void unblockAllDevicesForUser_NullEmployeeId_LogsWarningAndReturns() {
+            // when
+            biometricFailureService.unblockAllDevicesForUser(null);
+
+            // then - 아무 동작도 하지 않음
+            verifyNoInteractions(redisTemplate);
+        }
+
+        @Test
+        @DisplayName("사원번호가 빈 문자열이면 경고 로그만 남기고 종료한다")
+        void unblockAllDevicesForUser_EmptyEmployeeId_LogsWarningAndReturns() {
+            // when
+            biometricFailureService.unblockAllDevicesForUser("");
+
+            // then - 아무 동작도 하지 않음
+            verifyNoInteractions(redisTemplate);
+        }
+    }
+
+    @Nested
+    @DisplayName("통합 시나리오 테스트")
+    class IntegrationScenarioTest {
+
+        @Test
+        @DisplayName("실패 3회 후 차단되는 전체 플로우 테스트")
+        void fullFailureFlow_ThreeFailuresLeadsToBlock() {
+            // 새로운 mock 인스턴스들을 생성하여 테스트 격리
+            RedisTemplate<String, String> isolatedRedisTemplate = mock(RedisTemplate.class);
+            ValueOperations<String, String> isolatedValueOperations = mock(ValueOperations.class);
+            SetOperations<String, String> isolatedSetOperations = mock(SetOperations.class);
+
+            BiometricFailureServiceImpl isolatedService = new BiometricFailureServiceImpl(isolatedRedisTemplate);
+
+            // given
+            when(isolatedRedisTemplate.opsForValue()).thenReturn(isolatedValueOperations);
+            when(isolatedRedisTemplate.opsForSet()).thenReturn(isolatedSetOperations);
+            when(isolatedRedisTemplate.execute(any(DefaultRedisScript.class), anyList(), anyString()))
+                    .thenReturn(1L, 2L, 3L);
+            when(isolatedValueOperations.get(anyString()))
+                    .thenReturn("1", "2", "3");
+
+            // isDeviceBlocked 호출을 위한 hasKey mock
+            when(isolatedRedisTemplate.hasKey(anyString())).thenReturn(true);
+
+            // when & then
+            // 첫 번째 실패
+            int firstFail = isolatedService.incrementFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+            assertThat(firstFail).isEqualTo(1);
+            assertThat(isolatedService.hasExceededMaxAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID)).isFalse();
+
+            // 두 번째 실패
+            int secondFail = isolatedService.incrementFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+            assertThat(secondFail).isEqualTo(2);
+            assertThat(isolatedService.hasExceededMaxAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID)).isFalse();
+
+            // 세 번째 실패 (차단 조건 충족)
+            int thirdFail = isolatedService.incrementFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+            assertThat(thirdFail).isEqualTo(3);
+            assertThat(isolatedService.hasExceededMaxAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID)).isTrue();
+
+            // 디바이스 차단
+            isolatedService.blockDevice(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+
+            // 차단 상태 확인
+            assertThat(isolatedService.isDeviceBlocked(TEST_EMPLOYEE_ID, TEST_DEVICE_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 후 실패 카운트 초기화 시나리오")
+        void successAfterFailures_ClearsFailCount() {
+            // 새로운 mock 인스턴스들을 생성하여 테스트 격리
+            RedisTemplate<String, String> isolatedRedisTemplate = mock(RedisTemplate.class);
+            ValueOperations<String, String> isolatedValueOperations = mock(ValueOperations.class);
+            SetOperations<String, String> isolatedSetOperations = mock(SetOperations.class);
+
+            BiometricFailureServiceImpl isolatedService = new BiometricFailureServiceImpl(isolatedRedisTemplate);
+
+            // given
+            when(isolatedRedisTemplate.opsForValue()).thenReturn(isolatedValueOperations);
+            when(isolatedRedisTemplate.opsForSet()).thenReturn(isolatedSetOperations);
+            when(isolatedRedisTemplate.execute(any(DefaultRedisScript.class), anyList(), anyString()))
+                    .thenReturn(2L);
+            when(isolatedValueOperations.get(anyString()))
+                    .thenReturn("2")
+                    .thenReturn((String) null);
+
+            // when
+            // 실패 2회
+            isolatedService.incrementFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+            assertThat(isolatedService.getFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID)).isEqualTo(2);
+
+            // 성공으로 인한 초기화
+            isolatedService.clearFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID);
+            assertThat(isolatedService.getFailCount(TEST_EMPLOYEE_ID, TEST_DEVICE_ID)).isEqualTo(0);
+
+            // then
+            assertThat(isolatedService.getRemainingAttempts(TEST_EMPLOYEE_ID, TEST_DEVICE_ID)).isEqualTo(3);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#18 

## 📝 요약(Summary)

[refactor: BiometricFailureService 인터페이스 분리 및 Redis luaScript 적용, 로직 개선](https://github.com/Team-SSOK/ssom-backend/commit/21a50b36c2dc7ec5f1746c700821801e5a3f7a2a) 

- BiometricFailureService를 인터페이스와 구현체로 분리
  - 인터페이스: BiometricFailureService
  - 구현체: BiometricFailureServiceImpl

- Redis 연산 안정성 개선
  - incrementFailCount에서 Lua 스크립트를 사용한 원자적 연산 적용 -> Prod 환경에서 트랜잭션 문제 우려
  - NumberFormatException 처리 추가 및 잘못된 값 자동 복구
  - 입력값 검증 로직 추가

- 성능 최적화
  - unblockAllDevicesForUser에서 Redis keys() 대신 Set 기반 추적 방식 도입
  - keys() 패턴 검색은 fallback 메서드로만 제한적 사용
  
  [test: BiometricFailureService 통합 테스트 구현](https://github.com/Team-SSOK/ssom-backend/commit/234889343801e3d8b1e4486fc1701c74fd5ada01) 

- 실패 횟수 증가/조회/초기화 기능 테스트 추가
- 최대 시도 횟수 초과 확인 로직 테스트 추가
- 디바이스 차단/해제 기능 테스트 추가
- 사용자별 모든 디바이스 차단 해제 기능 테스트 추가
- 예외 상황 및 에러 처리 테스트 추가
- 실제 시나리오 기반 통합 테스트 추가
- Redis 연동 실패 시 fallback 동작 테스트 추가

## 📸스크린샷 (선택)
