### PR TITLE
fix: LogDataDto 수정 및 로그 조회 개수 변경

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/logging/dto/LogDataDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/logging/dto/LogDataDto.java
@@ -19,4 +19,7 @@ public class LogDataDto {
     private String thread;
     private String message;
     private String app;
+
+    @JsonProperty("stack_trace")
+    private String stackTrace;
 }

--- a/src/main/java/kr/ssok/ssom/backend/domain/logging/service/Impl/LoggingServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/logging/service/Impl/LoggingServiceImpl.java
@@ -119,7 +119,7 @@ public class LoggingServiceImpl implements LoggingService {
                                     .includes("@timestamp", "level", "logger", "thread", "message", "app")
                             )
                     )
-                    .size(10000) // 1000개 제한
+                    .size(3000) // 3000개 제한
                     .build();
 
             SearchResponse<LogDataDto> response = openSearchClient.search(request, LogDataDto.class);


### PR DESCRIPTION
## #️⃣ Issue Number


## 📝 요약(Summary)

- LogDataDto에 stack_trace 필드 추가
- 로그 목록 조회 시 최대 3000개 조회하도록 변경

## 📸스크린샷 (선택)
