### PR TITLE
feat: 전체 Issue 목록 조회 시 OPEN 상태만 반환하도록 수정

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/issue/service/Impl/IssueServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/issue/service/Impl/IssueServiceImpl.java
@@ -188,13 +188,13 @@ public class IssueServiceImpl implements IssueService {
     }
     
     /**
-     * 전체 Issue 목록 조회 (팀 공유)
+     * 전체 Issue 목록 조회 (팀 공유) - OPEN 상태만
      */
     @Override
     public List<IssueResponseDto> getAllIssues(String employeeId) {
-        log.info("전체 Issue 목록 조회 - 요청자: {}", employeeId);
+        log.info("전체 Issue 목록 조회 (OPEN 상태만) - 요청자: {}", employeeId);
         
-        List<Issue> issues = issueRepository.findAllByOrderByCreatedAtDesc();
+        List<Issue> issues = issueRepository.findByStatusOrderByCreatedAtDesc(IssueStatus.OPEN);
         
         return issues.stream()
                 .map(IssueResponseDto::from)


### PR DESCRIPTION
## #️⃣ Issue Number

#18 

## 📝 요약(Summary)

- IssueServiceImpl.getAllIssues() 메서드에서 모든 상태의 이슈 대신 OPEN 상태의 이슈만 조회하도록 변경
- findAllByOrderByCreatedAtDesc() → findByStatusOrderByCreatedAtDesc(IssueStatus.OPEN) 로 수정
- 기존 Repository의 findByStatusOrderByCreatedAtDesc() 메서드 활용

## 📸스크린샷 (선택)
