### PR TITLE
feat: SSE 토큰 만료 문제 해결을 위한 전용 장기 토큰 도입

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/dto/LoginResponseDto.java
@@ -9,6 +9,7 @@ public class LoginResponseDto {
     // 기존 필드들 (기존 로그인 API와 호환성 유지)
     private String accessToken;
     private String refreshToken;
+    private String sseToken; // SSE 전용 토큰 추가
     
     // 생체인증 로그인을 위한 추가 필드들
     private String username;

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/BiometricServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/BiometricServiceImpl.java
@@ -169,6 +169,7 @@ public class BiometricServiceImpl implements BiometricService {
             // 7. JWT 토큰 생성
             String accessToken = jwtTokenProvider.createAccessToken(user.getId());
             String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+            String sseToken = jwtTokenProvider.createSseToken(user.getId()); // SSE 토큰 추가
 
             // 토큰 만료 시간 계산
             long expirationTime = jwtTokenProvider.getTokenExpirationTime(refreshToken);
@@ -197,6 +198,7 @@ public class BiometricServiceImpl implements BiometricService {
             return LoginResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .sseToken(sseToken) // SSE 토큰 추가
                 .username(user.getUsername())
                 .department(user.getDepartment().getPrefix())
                 .expiresIn(expirationTime)

--- a/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/UserServiceImpl.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/user/service/Impl/UserServiceImpl.java
@@ -127,6 +127,7 @@ public class UserServiceImpl implements UserService {
         // 토큰 생성 (사원번호를 userId로 사용)
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        String sseToken = jwtTokenProvider.createSseToken(user.getId()); // SSE 토큰 추가
 
         // Refresh Token을 Redis에 저장
         String refreshTokenKey = REFRESH_TOKEN_PREFIX + user.getId();
@@ -151,6 +152,7 @@ public class UserServiceImpl implements UserService {
         return LoginResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .sseToken(sseToken) // SSE 토큰 추가
                 .username(user.getUsername())
                 .department(user.getDepartment().getPrefix()) // 부서 정보 prefix 값으로 응답
                 .expiresIn(expirationTime)
@@ -192,6 +194,7 @@ public class UserServiceImpl implements UserService {
         // 새 토큰 생성
         String newAccessToken = jwtTokenProvider.createAccessToken(user.getId());
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        String newSseToken = jwtTokenProvider.createSseToken(user.getId()); // SSE 토큰 추가
 
         // 기존 Refresh Token 삭제
         redisTemplate.delete(refreshTokenKey);
@@ -212,6 +215,7 @@ public class UserServiceImpl implements UserService {
         return LoginResponseDto.builder()
                 .accessToken(newAccessToken)
                 .refreshToken(newRefreshToken)
+                .sseToken(newSseToken) // SSE 토큰 추가
                 .username(user.getUsername())
                 .department(user.getDepartment().getPrefix())
                 .expiresIn(expirationTime)


### PR DESCRIPTION
## #️⃣ Issue Number

#172 

## 📝 요약(Summary)

JWT 30분 유효기간과 SSE 장시간 연결 요구사항 불일치로 발생하던
반복적인 연결 실패를 해결하기 위해 12시간 유효한 SSE 전용 토큰 시스템 추가

- SSE 전용 토큰 생성/검증 로직 구현
- 로그인 시 accessToken, refreshToken, sseToken 동시 발급
- 토큰 타입별 인증 정책 분리 적용
- 무의미한 재연결 시도로 인한 로그 스팸 및 서버 부하 해결

## 📸스크린샷 (선택)
