### PR TITLE
test : countByCreatedAtAfter 안쓰는 JPA 메서드 삭제

### DIFF
--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/repository/AlertRepository.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/repository/AlertRepository.java
@@ -16,9 +16,7 @@ public interface AlertRepository extends JpaRepository<Alert, Long> {
     
     // 성능 테스트를 위한 추가 메서드들
     List<Alert> findByIdContaining(String keyword);
-    
-    long countByCreatedAtAfter(LocalDateTime dateTime);
-    
+
     Optional<Alert> findByAlertId(Long alertId);
 }
 

--- a/src/main/java/kr/ssok/ssom/backend/domain/alert/repository/AlertStatusRepository.java
+++ b/src/main/java/kr/ssok/ssom/backend/domain/alert/repository/AlertStatusRepository.java
@@ -30,10 +30,7 @@ public interface AlertStatusRepository extends JpaRepository<AlertStatus, Long> 
     
     // alertId (PK)와 userId로 중복 체크 (성능 최적화)
     boolean existsByAlert_AlertIdAndUser_Id(Long alertId, String userId);
-    
-    // 성능 테스트를 위한 추가 메서드들
-    long countByCreatedAtAfter(LocalDateTime dateTime);
-    
+
     void deleteByAlert_AlertId(Long alertId);
 }
 


### PR DESCRIPTION
## #️⃣ Issue Number

#186 

## 📝 요약(Summary)

test : countByCreatedAtAfter 안쓰는 JPA 메서드 삭제

## 📸스크린샷 (선택)
